### PR TITLE
Fix: RPC/REST service startup

### DIFF
--- a/src/api/listeners/ServerStartedListener.ts
+++ b/src/api/listeners/ServerStartedListener.ts
@@ -103,6 +103,10 @@ export class ServerStartedListener implements interfaces.Listener {
             if (this.coreConnectionStatusService.connectionStatus === CoreConnectionStatusServiceStatus.CONNECTED
                 && this.BOOTSTRAPPING) {
                 this.STOP = await this.bootstrap()
+                    .then((started) => {
+                        this.isStarted = started;
+                        return started;
+                    })
                     .catch(reason => {
                         this.log.error('ERROR: marketplace bootstrap failed: ', reason);
                         // stop if there's an error
@@ -203,7 +207,7 @@ export class ServerStartedListener implements interfaces.Listener {
             throw new MessageException('Missing default Market configuration.');
         }
 
-        this.log.debug('bootstrap(), DONE');
+        this.log.info('bootstrap(), DONE');
 
         return true;
     }


### PR DESCRIPTION
Both RestApiMiddleware.ts and RpcMiddleware.ts depends on `ServerStartedListener`'s `isStarted` property in order to start responding to requests. There is currently nowhere that the `isStarted` property is actually set, and so remains at its default value of false.

This fix just sets the value accordingly.

_Also side note: the "bootstrap(), DONE" log message has been changed to be an info logtype (instead of debug) as this message seems to be a decent indication that the service is started and ready._