### PR TITLE
Listing item category search update

### DIFF
--- a/src/api/models/ListingItem.ts
+++ b/src/api/models/ListingItem.ts
@@ -174,6 +174,20 @@ export class ListingItem extends Bookshelf.Model<ListingItem> {
                     qb.innerJoin('item_categories', 'item_categories.id', 'item_informations.item_category_id');
                     qb.where('item_categories.key', '=', options.category);
                     ListingItem.log.debug('...searchBy by category.key: ', options.category);
+                } else if (
+                    options.category &&
+                    (Object.prototype.toString.call(options.category) === '[object Array]') &&
+                    (typeof options.category[0] === 'number')
+                ) {
+                    qb.innerJoin('item_categories', 'item_categories.id', 'item_informations.item_category_id');
+                    qb.whereIn('item_categories.id', options.category as number[]);
+                } else if (
+                    options.category &&
+                    (Object.prototype.toString.call(options.category) === '[object Array]') &&
+                    typeof options.category[0] === 'string'
+                ) {
+                    qb.innerJoin('item_categories', 'item_categories.id', 'item_informations.item_category_id');
+                    qb.whereIn('item_categories.key', options.category as string[]);
                 }
 
                 // searchBy by profile

--- a/src/api/repositories/ProposalRepository.ts
+++ b/src/api/repositories/ProposalRepository.ts
@@ -26,7 +26,7 @@ export class ProposalRepository {
 
     /**
      *
-     * @param {ListingItemSearchParams} options
+     * @param {ProposalSearchParams} options
      * @param {boolean} withRelated
      * @returns {Promise<Bookshelf.Collection<ListingItem>>}
      */

--- a/src/api/requests/search/ListingItemSearchParams.ts
+++ b/src/api/requests/search/ListingItemSearchParams.ts
@@ -17,7 +17,7 @@ export class ListingItemSearchParams extends RequestBody {
     @IsNotEmpty()
     @IsEnum(SearchOrder)
     public order: SearchOrder;
-    public category: string | number;
+    public category: string | number | Array<string|number>;
     // @ValidateIf(o => o.type)
     // @IsEnum(ListingItemSearchType)
     public type: ListingItemSearchType; // TODO: not used for anything


### PR DESCRIPTION
Allows for listing items to be searched for by specifying multiple (unrelated) category items.

Currently, the behaviour of listing item searches with a category specified seems to return items from categories that are children categories to the specified category as well. Which is great. But there is no option to currently allow for distinct sibling category searches (where not all siblings are searched for), or where the categories are unrelated to each other.

This change attempts to cater for such requirements.