### PR TITLE
Applies fixes to the MarketAddCommand validation

### DIFF
--- a/src/api/commands/market/MarketAddCommand.ts
+++ b/src/api/commands/market/MarketAddCommand.ts
@@ -123,13 +123,13 @@ export class MarketAddCommand extends BaseCommand implements RpcCommandInterface
             throw new InvalidParamException('profileId', 'number');
         } else if (typeof name !== 'string') {
             throw new InvalidParamException('name', 'string');
-        } else if (type !== undefined && typeof type !== 'string') {
+        } else if (type && typeof type !== 'string') {
             throw new InvalidParamException('type', 'string');
-        } else if (receiveKey !== undefined && typeof receiveKey !== 'string') {
+        } else if (receiveKey && typeof receiveKey !== 'string') {
             throw new InvalidParamException('receiveKey', 'string');
         // } else if (receiveAddress !== undefined && typeof receiveAddress !== 'string') {
         //     throw new InvalidParamException('receiveAddress', 'string');
-        } else if (publishKey !== undefined && typeof publishKey !== 'string') {
+        } else if (publishKey && typeof publishKey !== 'string') {
             throw new InvalidParamException('publishKey', 'string');
         // } else if (publishAddress !== undefined && typeof publishAddress !== 'string') {
         //     throw new InvalidParamException('publishAddress', 'string');
@@ -223,7 +223,7 @@ export class MarketAddCommand extends BaseCommand implements RpcCommandInterface
         }
 
         let identity: resources.Identity;
-        if (!_.isEmpty(identityId)) {
+        if (identityId) {
             // make sure Identity with the id exists
             identity = await this.identityService.findOne(identityId)
                 .then(value => value.toJSON())


### PR DESCRIPTION
- the market type, receiveKey, and publishKey values may not necessarily be undefined -> they could be null as well if one of the later optional parameters are specified (eg: if the identityId value is specified, then the undefined parameters are converted to null values in the array for the network request);
- isEmpty() from lodash always returns true is a numeric argument is tested, resulting in the specified identityId value always being ignored and a new market always being created instead of assigning to an existing identity.