### PR TITLE
Fixes startup smsg poll when DB is empty.

### DIFF
--- a/src/api/services/SmsgService.ts
+++ b/src/api/services/SmsgService.ts
@@ -95,11 +95,11 @@ export class SmsgService {
                     return undefined;
                 });
             if (!lastSmsgMessage) {
-                return {
-                    numsent: 0
-                } as SmsgZmqPushResult;
+                const earliestDate = 60 * 60 * 24 * parseInt(process.env.PAID_MESSAGE_RETENTION_DAYS, 10);
+                from = Math.trunc(Date.now() / 1000) - earliestDate;
+            } else {
+                from = Math.trunc(lastSmsgMessage.received / 1000);
             }
-            from = Math.trunc(lastSmsgMessage.received / 1000);
         }
 
         if (!to) {


### PR DESCRIPTION
When starting up, the core rpc command 'smsgzmqpush' is used to poll the DB to send any missed smsg messages. However, such a poll is based on the last date that an smsg message occurred, but if the DB has no previous smsg messages then such a request is never made.

This change fixes this to then instead use the maximum duration possible instead to determine from when to request messages from core: a paid message duration.
Note that in the case of duplicate messages, the DB already has a unique constraint on the msgid and direction of the message, which correctly fails for duplicate messages found, and thus the case for potential duplicated messages requires no additional handling with this change.