### PR TITLE
Prevents exception from being thrown when a ListingItem has not been created

### DIFF
--- a/src/api/services/action/ListingItemAddActionService.ts
+++ b/src/api/services/action/ListingItemAddActionService.ts
@@ -184,18 +184,22 @@ export class ListingItemAddActionService extends BaseActionService {
         // only send notifications when receiving messages
         if (ActionDirection.INCOMING === actionDirection) {
 
-            const listingItem: resources.ListingItem = await this.listingItemService.findOneByMsgId(smsgMessage.msgid).then(value => value.toJSON());
+            const listingItem: resources.ListingItem = await this.listingItemService.findOneByMsgId(smsgMessage.msgid)
+                .then(value => value.toJSON())
+                .catch(err => undefined);
 
-            const notification: MarketplaceNotification = {
-                event: NotificationType[marketplaceMessage.action.type],    // TODO: NotificationType could be replaced with ActionMessageTypes
-                payload: {
-                    id: listingItem.id,
-                    hash: listingItem.hash,
-                    seller: listingItem.seller,
-                    market: listingItem.market
-                } as ListingItemNotification
-            };
-            return notification;
+            if (listingItem) {
+                const notification: MarketplaceNotification = {
+                    event: NotificationType[marketplaceMessage.action.type],    // TODO: NotificationType could be replaced with ActionMessageTypes
+                    payload: {
+                        id: listingItem.id,
+                        hash: listingItem.hash,
+                        seller: listingItem.seller,
+                        market: listingItem.market
+                    } as ListingItemNotification
+                };
+                return notification;
+            }
         }
         return undefined;
     }


### PR DESCRIPTION
Which occurs when a ListingItemAdd message has been received but a ListingItem object is not saved to the DB.  The latter can occur when the `validContent` variable in `BaseActionMessageProcessor.process()` is false: an exception is thrown because the call to `listingItemService.findOneByMessageId()` throws due to the listing item not having been created. This just catches and handles the ListingItemAddActionService.createNotification() case specifically.