### PR TITLE
Force a new DB to be created for the v0.3 release

### DIFF
--- a/src/core/helpers/DataDir.ts
+++ b/src/core/helpers/DataDir.ts
@@ -37,6 +37,7 @@ export class DataDir {
 
         let dir = '';
         const appName = 'particl-market';
+        const checkpoint = '03';
 
         switch (process.platform) {
             case 'linux': {
@@ -57,7 +58,7 @@ export class DataDir {
 
         // return path to datadir (mainnet vs testnet)
         // and set the main datadir variable.
-        const dataDir = path.join(dir, (Environment.isRegtest() ? 'regtest' : ( Environment.isTestnet() ? 'testnet' : '') ));
+        const dataDir = path.join(dir, (Environment.isRegtest() ? 'regtest' : ( Environment.isTestnet() ? 'testnet' : '') ), checkpoint);
         return dataDir;
     }
 


### PR DESCRIPTION
Considering that the change between v0.2 and v0.3 is not backwards compatible, this change ensures that a new MP database is created for >=v0.3.x, and an existing <=v0.2 MP database remains for any outstanding activity the user might have ongoing in v0.2 that is incompatible with the 0.3 release.