### PR TITLE
Creates separation between old and new MP versions

### DIFF
--- a/src/api/enums/ActionMessageTypes.ts
+++ b/src/api/enums/ActionMessageTypes.ts
@@ -8,3 +8,11 @@ import { MPActionExtended } from './MPActionExtended';
 import { CommentAction } from './CommentAction';
 
 export type ActionMessageTypes = MPAction | MPActionExtended | GovernanceAction | CommentAction;
+
+
+export function hasActionMessageType(typedValue: string): boolean {
+    return  (Object as any).values(MPAction).includes(typedValue) ||
+            (Object as any).values(MPActionExtended).includes(typedValue) ||
+            (Object as any).values(GovernanceAction).includes(typedValue) ||
+            (Object as any).values(CommentAction).includes(typedValue);
+}

--- a/src/api/messageprocessors/CoreMessageProcessor.ts
+++ b/src/api/messageprocessors/CoreMessageProcessor.ts
@@ -24,6 +24,7 @@ import PriorityQueue, { PriorityQueueOptions } from 'pm-queue/dist/priority-queu
 import { MessageQueuePriority } from '../enums/MessageQueuePriority';
 import { SmsgMessageStatus } from '../enums/SmsgMessageStatus';
 import { MarketplaceMessageProcessor } from './MarketplaceMessageProcessor';
+import { hasActionMessageType } from '../enums/ActionMessageTypes';
 
 export class CoreMessageProcessor implements MessageProcessorInterface {
 
@@ -135,7 +136,8 @@ export class CoreMessageProcessor implements MessageProcessorInterface {
     private async isMarketplaceMessage(msg: CoreSmsgMessage): Promise<boolean> {
         try {
             const marketplaceMessage: MarketplaceMessage = JSON.parse(msg.text);
-            return marketplaceMessage.action ? true : false;
+            const actionValue: string = (marketplaceMessage.action && marketplaceMessage.action.type) || '';
+            return hasActionMessageType(actionValue);
         } catch (e) {
             return false;
         }

--- a/src/core/helpers/DataDir.ts
+++ b/src/core/helpers/DataDir.ts
@@ -37,6 +37,7 @@ export class DataDir {
 
         let dir = '';
         const appName = 'particl-market';
+        const checkpoint = '03';
 
         switch (process.platform) {
             case 'linux': {
@@ -57,7 +58,7 @@ export class DataDir {
 
         // return path to datadir (mainnet vs testnet)
         // and set the main datadir variable.
-        const dataDir = path.join(dir, (Environment.isRegtest() ? 'regtest' : ( Environment.isTestnet() ? 'testnet' : '') ));
+        const dataDir = path.join(dir, (Environment.isRegtest() ? 'regtest' : ( Environment.isTestnet() ? 'testnet' : '') ), checkpoint);
         return dataDir;
     }
 


### PR DESCRIPTION
Considering that the change between v0.2 and v0.3 releases are not scheduled to be backwards compatible, this change ensures that a new MP database is created for >=v0.3.x, and an existing <=v0.2 MP database remains for any outstanding activity the user might have ongoing in v0.2 that is incompatible with the 0.3 release.

Also prevents the MP from attempting to process marketplace messages that are designated for the older MP versions (relates to https://github.com/xludx/omp-lib/pull/2 ).
This latter part of the change is not exactly ideal, but it works and ensures that only messages designated for the current version are processed (others are ignored).