### PR TITLE
Fixes some template creation, update and size request issues.

### DIFF
--- a/src/api/commands/iteminformation/ItemInformationUpdateCommand.ts
+++ b/src/api/commands/iteminformation/ItemInformationUpdateCommand.ts
@@ -54,13 +54,18 @@ export class ItemInformationUpdateCommand extends BaseCommand implements RpcComm
         const listingItemTemplate: resources.ListingItemTemplate = data.params[0];
         const itemCategory: resources.ItemCategory = data.params[4];
 
+        let category = {};
+        if (!_.isEmpty(data.params[4])) {
+            category = {
+                key: itemCategory.key
+            };
+        }
+
         return this.itemInformationService.update(listingItemTemplate.ItemInformation.id, {
             title: data.params[1],
             shortDescription: data.params[2],
             longDescription: data.params[3],
-            itemCategory: {
-                key: itemCategory.key
-            } as ItemCategoryUpdateRequest
+            itemCategory: category as ItemCategoryUpdateRequest
         } as ItemInformationUpdateRequest);
     }
 
@@ -70,7 +75,7 @@ export class ItemInformationUpdateCommand extends BaseCommand implements RpcComm
      *  [1]: title
      *  [2]: shortDescription
      *  [3]: longDescription
-     *  [4]: categoryId
+     *  [4]: categoryId (optional)
      *
      * @param {RpcRequest} data
      * @returns {Promise<RpcRequest>}
@@ -84,8 +89,6 @@ export class ItemInformationUpdateCommand extends BaseCommand implements RpcComm
             throw new MissingParamException('shortDescription');
         } else if (data.params.length < 4) {
             throw new MissingParamException('longDescription');
-        } else if (data.params.length < 5) {
-            throw new MissingParamException('categoryId');
         }
 
         if (typeof data.params[0] !== 'number') {
@@ -96,7 +99,7 @@ export class ItemInformationUpdateCommand extends BaseCommand implements RpcComm
             throw new InvalidParamException('shortDescription', 'string');
         } else if (typeof data.params[3] !== 'string') {
             throw new InvalidParamException('longDescription', 'string');
-        } else if (typeof data.params[4] !== 'number') {
+        } else if (data.params[4] && typeof data.params[4] !== 'number') {
             throw new InvalidParamException('categoryId', 'number');
         }
 
@@ -115,13 +118,16 @@ export class ItemInformationUpdateCommand extends BaseCommand implements RpcComm
         }
 
         // make sure ItemCategory with the id exists
-        const itemCategory: resources.ItemCategory = await this.itemCategoryService.findOne(data.params[4])
-            .then(value => {
-                return value.toJSON();
-            })
-            .catch(reason => {
-                throw new ModelNotFoundException('ItemCategory');
-            });
+        if (+data.params[4]) {
+            const itemCategory: resources.ItemCategory = await this.itemCategoryService.findOne(data.params[4])
+                .then(value => {
+                    return value.toJSON();
+                })
+                .catch(reason => {
+                    throw new ModelNotFoundException('ItemCategory');
+                });
+            data.params[4] = itemCategory;
+        }
 
         const isModifiable = await this.listingItemTemplateService.isModifiable(listingItemTemplate.id);
         if (!isModifiable) {
@@ -129,7 +135,6 @@ export class ItemInformationUpdateCommand extends BaseCommand implements RpcComm
         }
 
         data.params[0] = listingItemTemplate;
-        data.params[4] = itemCategory;
 
         return data;
     }
@@ -149,7 +154,7 @@ export class ItemInformationUpdateCommand extends BaseCommand implements RpcComm
             + '                                     information we\'re updating. \n'
             + '    <longDescription>             - String - The new long description of the item \n'
             + '                                     information we\'re updating. \n'
-            + '    <categoryId>                  - String - The ID that identifies the new \n'
+            + '    <categoryId>                  - String - optional - The ID that identifies the new \n'
             + '                                     category we want to assign to the item \n'
             + '                                     information we\'re updating. ';
     }

--- a/src/api/commands/itemlocation/ItemLocationUpdateCommand.ts
+++ b/src/api/commands/itemlocation/ItemLocationUpdateCommand.ts
@@ -55,7 +55,6 @@ export class ItemLocationUpdateCommand extends BaseCommand implements RpcCommand
 
         const listingItemTemplate: resources.ListingItemTemplate = data.params[0];
         const countryCode = data.params[1];
-        const address = data.params[2];
 
         const itemInformation = await this.getItemInformation(listingItemTemplate.id);
 
@@ -101,7 +100,7 @@ export class ItemLocationUpdateCommand extends BaseCommand implements RpcCommand
             throw new InvalidParamException('listingItemTemplateId', 'number');
         } else if (typeof data.params[1] !== 'string') {
             throw new InvalidParamException('country', 'string');
-        } else if (typeof data.params[2] !== 'string') {
+        } else if (data.params[2] && typeof data.params[2] !== 'string') {
             throw new InvalidParamException('address', 'string');
         }
 

--- a/src/api/factories/ItemCategoryFactory.ts
+++ b/src/api/factories/ItemCategoryFactory.ts
@@ -6,8 +6,7 @@ import * as _ from 'lodash';
 import * as resources from 'resources';
 import { inject, named } from 'inversify';
 import { Logger as LoggerType } from '../../core/Logger';
-import { Types, Core, Targets } from '../../constants';
-import { ItemCategory } from '../models/ItemCategory';
+import { Types, Core } from '../../constants';
 import { ItemCategoryCreateRequest } from '../requests/model/ItemCategoryCreateRequest';
 import { NotFoundException } from '../exceptions/NotFoundException';
 import { hash } from 'omp-lib/dist/hasher/hash';
@@ -107,6 +106,9 @@ export class ItemCategoryFactory {
      * @returns {Promise<string[]>}
      */
     public async getArray(category: resources.ItemCategory): Promise<string[]> {
+        if (!category) {
+            return [];
+        }
         return await this.getArrayInner(category);
     }
 

--- a/src/api/factories/message/ListingItemAddMessageFactory.ts
+++ b/src/api/factories/message/ListingItemAddMessageFactory.ts
@@ -71,13 +71,11 @@ export class ListingItemAddMessageFactory implements MessageFactoryInterface {
         const payment = await this.getMessagePayment(params.listingItem.PaymentInformation, params.cryptoAddress);
         const messaging = await this.getMessageMessaging(params.listingItem.MessagingInformation);
         const objects = await this.getMessageObjects(params.listingItem.ListingItemObjects);
+        const seller = _.isEmpty(params.seller) ? {} : { address: params.seller.address, signature: params.signature };
 
         const item = {
             information,
-            seller: {
-                address: params.seller.address,
-                signature: params.signature
-            } as SellerInfo,
+            seller,
             payment,
             messaging,
             objects

--- a/src/api/factories/model/ListingItemTemplateFactory.ts
+++ b/src/api/factories/model/ListingItemTemplateFactory.ts
@@ -69,6 +69,7 @@ export class ListingItemTemplateFactory implements ModelFactoryInterface {
                 escrow: {
                     type: params.escrowType,
                     secondsToLock: 0,
+                    releaseType: params.escrowReleaseType,
                     ratio: {
                         buyer: params.buyerRatio,
                         seller: params.sellerRatio
@@ -78,9 +79,9 @@ export class ListingItemTemplateFactory implements ModelFactoryInterface {
         } as ListingItemTemplateCreateRequest;
 
         // optional
-        if (params[13]) {
-            createRequest.parent_listing_item_template_id = params[13];
-        }
+        // if (params[13]) {
+        //     createRequest.parent_listing_item_template_id = params[13];
+        // }
 
         // hash should not be saved until just before the ListingItemTemplate is posted,
         // since ListingItemTemplates with hash should not be modified anymore

--- a/src/api/services/model/ListingItemTemplateService.ts
+++ b/src/api/services/model/ListingItemTemplateService.ts
@@ -444,20 +444,20 @@ export class ListingItemTemplateService {
 
         // this.log.debug('marketplacemessage: ', JSON.stringify(marketPlaceMessage, null, 2));
 
-        let imageDataSize = 0;
-        if (action.item.information.images) {
-            for (const image of action.item.information.images) {
-                imageDataSize = imageDataSize + image.data[0].data.length;
-                this.log.debug('imageDataSize: ', image.data[0].data.length);
-            }
-        }
-        const messageDataSize = JSON.stringify(marketplaceMessage).length - imageDataSize;
-        const spaceLeft = ListingItemTemplateService.MAX_SMSG_SIZE - messageDataSize - imageDataSize;
+        // let imageDataSize = 0;
+        // if (action.item.information.images) {
+        //     for (const image of action.item.information.images) {
+        //         imageDataSize = imageDataSize + image.data[0].data.length;
+        //         this.log.debug('imageDataSize: ', image.data[0].data.length);
+        //     }
+        // }
+        const messageDataSize = JSON.stringify(marketplaceMessage).length; // - imageDataSize;
+        const spaceLeft = ListingItemTemplateService.MAX_SMSG_SIZE - messageDataSize; // - imageDataSize;
         const fits = spaceLeft > 0;
 
         return {
             messageData: messageDataSize,
-            imageData: imageDataSize,
+            // imageData: imageDataSize,
             spaceLeft,
             fits
         } as MessageSize;


### PR DESCRIPTION
Makes the following modifications:

* Removes the image size calculations from the template size calculations. Based on the assumption that images are going to be included outside of the main data smsg messsage, AND the case that `image.data[0].data` is undefined because the `data` item is no longer seemingly included on the image data object. The latter issue can be fixed, but there's the question of whether its necessary based on the assumption.

* ItemLocationUpdateCommand modified to make the 'address' param actually optional. Its claimed to be optional, and the 'ItemLocationAddCommand' has it as optional, therefore the update command should have it as optional as well.

* Makes the 'categoryId' param on ItemInformationUpdateCommand to be optional, as the ItemInformationAddCommand has it as optional and in the same way the update command should therefore not force its inclusion.

* Prevents an error when using the ListingItemTemplateAddCommand concerning the escrow release type.

* Prevents errors occurring when using ListingItemTemplateSizeCommand, due to a template that may not have a category set yet (eg: if called immediately after adding a template without a category), as well as seller (address and signature) info missing, and some image related issues.  
