### PR TITLE
Fixes removal of a market not working if the market was flagged

### DIFF
--- a/src/database/migrations/20180104145917_create_flagged_items_table.ts
+++ b/src/database/migrations/20180104145917_create_flagged_items_table.ts
@@ -22,7 +22,7 @@ exports.up = (db: Knex): Promise<any> => {
 
             table.integer('market_id').unsigned().nullable();
             table.foreign('market_id').references('id')
-                .inTable('markets');
+                .inTable('markets').onDelete('CASCADE');
 
             table.timestamp('updated_at').defaultTo(db.fn.now());
             table.timestamp('created_at').defaultTo(db.fn.now());


### PR DESCRIPTION
After a market has been "flagged" (proposal created to remove the market), attempting to leave/remove the market (via `MarketRemoveCommand`) results in a SQL foreign key constraint error and the market not being removed.

Turns out that the flagged_items table references the market_id and with no cascade delete modifier applied to it. This change fixes this. 