### PR TITLE
Add order hash to bid message

### DIFF
--- a/src/api/messages/notification/BidNotification.ts
+++ b/src/api/messages/notification/BidNotification.ts
@@ -14,6 +14,7 @@ export type BidActionMessageTypes = MPAction.MPA_BID | MPAction.MPA_ACCEPT
 export class BidNotification implements ActionNotificationInterface {
     public objectId: number;
     public objectHash: string;
+    public orderHash: string;
 
     public from: string;        // was: bidder
     public to: string;

--- a/src/api/services/BaseBidActionService.ts
+++ b/src/api/services/BaseBidActionService.ts
@@ -12,6 +12,8 @@ import { Logger as LoggerType } from '../../core/Logger';
 import { ActionMessageValidatorInterface } from '../messagevalidators/ActionMessageValidatorInterface';
 import { NotifyService } from './NotifyService';
 import { ActionMessageTypes } from '../enums/ActionMessageTypes';
+import { ActionMessageObjects } from './../enums/ActionMessageObjects';
+import { KVS } from 'omp-lib/dist/interfaces/common';
 import { BaseActionService } from './BaseActionService';
 import { BidCreateRequest } from '../requests/model/BidCreateRequest';
 import { ListingItemService } from './model/ListingItemService';
@@ -98,11 +100,16 @@ export abstract class BaseBidActionService extends BaseActionService {
             .then(value => value.toJSON());
 
         if (bid) {
+            const orderHash = _.find(Array.isArray(bid.BidDatas) ? bid.BidDatas : [], (kvs: KVS) => {
+                return kvs.key === ActionMessageObjects.ORDER_HASH;
+            });
+
             return {
                 event: marketplaceMessage.action.type,
                 payload: {
                     objectId: bid.id,
                     objectHash: bid.hash,
+                    orderHash: orderHash ? orderHash.value : '',
                     from: smsgMessage.from,
                     to: smsgMessage.to,
                     target: bid.ListingItem.hash,

--- a/src/api/services/action/BidActionService.ts
+++ b/src/api/services/action/BidActionService.ts
@@ -232,11 +232,16 @@ export class BidActionService extends BaseActionService {
                 .then(value => value.toJSON());
 
             if (bid) {
+                const orderHash = _.find(Array.isArray(bid.BidDatas) ? bid.BidDatas : [], (kvs: KVS) => {
+                    return kvs.key === ActionMessageObjects.ORDER_HASH;
+                });
+
                 return {
                     event: marketplaceMessage.action.type,
                     payload: {
                         objectId: bid.id,
                         objectHash: bid.hash,
+                        orderHash: orderHash ? orderHash.value : '',
                         from: bid.bidder,
                         to: bid.OrderItem.Order.seller,
                         target: bid.ListingItem.hash,


### PR DESCRIPTION
Adds the order hash value into the bid notification messages.

Reasoning behind this: the bids are individual messages, that are essentially, related to a single entity (the order). When receiving one of these bid notification messages, the only way to identify what order the bid message applies to is to query the rpc API to extract the specific bid message. However, this is a waste, particularly when receiving a number of bid messages concurrently, and when the only need to do this is to simply retrieve an identifier to the related order item.
By adding the order hash (if available) into the bid notification message, such an identifier is easily available without the necessity of additional lookups.
