### PR TITLE
Fixes default shipping value creation as a part of ListingItem template creation.

### DIFF
--- a/src/api/factories/model/ListingItemTemplateFactory.ts
+++ b/src/api/factories/model/ListingItemTemplateFactory.ts
@@ -56,10 +56,10 @@ export class ListingItemTemplateFactory implements ModelFactoryInterface {
                     // } as CryptocurrencyAddressCreateRequest,
                     currency: params.currency,
                     basePrice: params.basePrice,
-                    shippingPrice: (params.domesticShippingPrice || params.internationalShippingPrice) ? {
-                        domestic: params.domesticShippingPrice,
-                        international: params.internationalShippingPrice
-                    } as ShippingPriceCreateRequest : undefined
+                    shippingPrice: {
+                        domestic: params.domesticShippingPrice ? params.domesticShippingPrice : 0,
+                        international: params.internationalShippingPrice ? params.internationalShippingPrice : 0
+                    } as ShippingPriceCreateRequest
                 } as ItemPriceCreateRequest,
                 escrow: {
                     type: params.escrowType,


### PR DESCRIPTION
When both the domesticShippingPrice and internationalShpipingPrice values provided are 0, this passes validation results in an error in omp-lib during hashing due to missing values in the template.

In other words, omp-lib attempts to validate, inside its hash function, the data provided via the `ListingItemTemplateCreateaRequest` against a template definition set, which explicitly provides the following mapping:

```ts
{
        from: 'PaymentInformation.ItemPrice.ShippingPrice.domestic',
        to: HashableItemField.PAYMENT_SHIPPING_PRICE_DOMESTIC
    }, {
        from: 'PaymentInformation.ItemPrice.ShippingPrice.international',
        to: HashableItemField.PAYMENT_SHIPPING_PRICE_INTL
    }
```
This errors out when both the `paymentInformation.ItemPrice.shippingPrice.domestic` and `paymentInformation.ItemPrice.shippingPrice.international` values are 0 (which is currently a valid case).

This pull request fixes this scenario by **not** setting the `paymentInformation.ItemPrice.shippingPrice` value to undefined if both domestic and international shipping values are falsey.

This fixes https://github.com/particl/particl-desktop/issues/1775