### PR TITLE
Adds additional validation to the orderitem status

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,27 +1,25 @@
 {
-    "version": "0.1.0",
+    "version": "2.0.0",
     "command": "npm",
-    "isShellCommand": true,
-    "suppressTaskName": true,
     "tasks": [
         {
-            // Build task, Cmd+Shift+B
-            // "npm run build"
-            "taskName": "build",
-            "isBuildCommand": true,
+            "label": "build",
+            "type": "shell",
             "args": [
                 "run",
                 "build"
-            ]
+            ],
+            "problemMatcher": [],
+            "group": "build"
         },
         {
-            // Test task, Cmd+Shift+T
-            // "npm test"
-            "taskName": "test",
-            "isTestCommand": true,
+            "label": "test",
+            "type": "shell",
             "args": [
                 "test"
-            ]
+            ],
+            "problemMatcher": [],
+            "group": "test"
         }
     ]
 }

--- a/src/api/enums/OrderItemStatusSequence.ts
+++ b/src/api/enums/OrderItemStatusSequence.ts
@@ -1,0 +1,17 @@
+// Copyright (c) 2017-2021, The Particl Market developers
+// Distributed under the GPL software license, see the accompanying
+// file COPYING or https://github.com/particl/particl-market/blob/develop/LICENSE
+
+import { OrderItemStatus } from './OrderItemStatus';
+
+/**
+ * OrderItemStatusSequence
+ *
+ * Allows for the definition of a validation hierarchy between OrderItemStatuses
+ */
+
+export type OrderItemStatusSequence = {
+    [state in OrderItemStatus]?: {
+        nextStates: OrderItemStatus[]
+    }
+};

--- a/src/api/messagevalidators/EscrowReleaseValidator.ts
+++ b/src/api/messagevalidators/EscrowReleaseValidator.ts
@@ -55,7 +55,7 @@ export class EscrowReleaseValidator implements ActionMessageValidatorInterface {
                     return child.type === MPActionExtended.MPA_SHIP;
                 });
 
-                return completeBid !== undefined && shipBid !== undefined;
+                return (completeBid !== undefined) || (shipBid !== undefined);
             })
             .catch( () => false);
     }

--- a/src/api/services/action/EscrowReleaseActionService.ts
+++ b/src/api/services/action/EscrowReleaseActionService.ts
@@ -36,6 +36,7 @@ import { NotifyService } from '../NotifyService';
 import { ActionDirection } from '../../enums/ActionDirection';
 import { MarketplaceNotification } from '../../messages/MarketplaceNotification';
 import { BlacklistService } from '../model/BlacklistService';
+import { MessageException } from '../../exceptions/MessageException';
 
 
 export class EscrowReleaseActionService extends BaseBidActionService {
@@ -156,7 +157,20 @@ export class EscrowReleaseActionService extends BaseBidActionService {
             .then(async value => {
                 const bid: resources.Bid = value.toJSON();
 
-                await this.orderItemService.updateStatus(bid.ParentBid.OrderItem.id, OrderItemStatus.COMPLETE);
+                const nextOrderStatus = OrderItemStatus.COMPLETE;
+
+                const isValid = bid.ParentBid.OrderItem.status && this.orderItemService.isNextStatusValid(
+                    bid.ParentBid.OrderItem.status,
+                    nextOrderStatus
+                );
+
+                if (!isValid) {
+                    throw new MessageException(
+                        `Invalid orderitem sequence for orderitem id ${bid.ParentBid.OrderItem.id}: ${bid.ParentBid.OrderItem.status} -> ${nextOrderStatus}`
+                    );
+                }
+
+                await this.orderItemService.updateStatus(bid.ParentBid.OrderItem.id, nextOrderStatus);
                 await this.orderService.updateStatus(bid.ParentBid.OrderItem.Order.id, OrderStatus.COMPLETE);
 
                 return await this.bidService.findOne(bid.id, true).then(bidModel => bidModel.toJSON());


### PR DESCRIPTION
This is intended to assist with ensuring orderitem status updates follow the correct sequence.

An example of a problem that may occur:
- Buyer places bid; seller receives bid message.
- Both buyer state and seller state match.
- Buyer cancels bid placement, but the cancellation message takes some time to be delivered (An alternative scenario is that the next step occurs but with a delay in the receipt of the seller's acceptance message)
- Seller, not having received the cancellation message, accepts the bid.
- Once the seller node receives the cancellation message, the seller node correctly processes the request and updates the order to reflect the cancellation.
The seller node in this example is correct, but the buyer node is not: from being cancelled, after receipt of the accept message the buyer node updates the order to reflect that it has been accepted. Worse, attempting to either cancel the order, or progress the order to the subsequent buyflow step, fails with error due to the expected outputs neither being locked nor potentially available.

Further, there are validators presently made available, such as the `validateSequence()` function found in various `messagevalidators/` files eg: `BidAcceptValidator.ts`. However, the majority of these perform simple checks that rely on a previous bid message already existing, which while it being a valid check, fails for checking the current state and whether the requested state can be entered into. For example, `validateSequence()` in `EscrowLockValidator.ts` checks whether a previous ACCEPT bid message has been received. For a cancelled bid, or even an already completed bid, this condition  would likely be true, however, in neither of these cases should the ESCROW_LOCK message be further processed.

This change attempts to introduce a rudimentary means for ensuring that orderitem statuses are not updated if the received bid messages does not follow the correct buyflow sequence, based on the current orderitem status and the current message attempting to update the order.