### PR TITLE
Fixes flagging/voting on duplicated listing items

### DIFF
--- a/src/api/models/ListingItem.ts
+++ b/src/api/models/ListingItem.ts
@@ -71,6 +71,18 @@ export class ListingItem extends Bookshelf.Model<ListingItem> {
         return ListingItemCollection.fetchAll(withRelated ? {withRelated: this.RELATIONS} : undefined);
     }
 
+    public static async fetchAllByHashAndMarketReceiveAddress(
+        hash: string, marketReceiveAddress: string, withRelated: boolean = true
+    ): Promise<Collection<ListingItem>> {
+        const ListingItemCollection = ListingItem.forge<Model<ListingItem>>()
+            .query(qb => {
+                qb.where('hash', '=', hash).andWhere('market', '=', marketReceiveAddress);
+            })
+            .orderBy('expiry_time', 'ASC');
+
+        return ListingItemCollection.fetchAll(withRelated ? {withRelated: this.RELATIONS} : undefined);
+    }
+
     public static async fetchById(value: number, withRelated: boolean = true): Promise<ListingItem> {
         return ListingItem.where<ListingItem>({ id: value }).fetch(withRelated ? {withRelated: this.RELATIONS} : undefined);
     }

--- a/src/api/repositories/ListingItemRepository.ts
+++ b/src/api/repositories/ListingItemRepository.ts
@@ -10,7 +10,6 @@ import { DatabaseException } from '../exceptions/DatabaseException';
 import { NotFoundException } from '../exceptions/NotFoundException';
 import { Logger as LoggerType } from '../../core/Logger';
 import { ListingItemSearchParams } from '../requests/search/ListingItemSearchParams';
-import {Proposal} from '../models/Proposal';
 
 export class ListingItemRepository {
 
@@ -24,8 +23,8 @@ export class ListingItemRepository {
     }
 
     public async findAll(): Promise<Bookshelf.Collection<ListingItem>> {
-        const list = await this.ListingItemModel.fetchAll();
-        return list as Bookshelf.Collection<ListingItem>;
+        const list = await this.ListingItemModel.fetchAll<ListingItem>();
+        return list;
     }
 /*
     public async findAllByCategory(categoryId: number, withRelated: boolean = true): Promise<Bookshelf.Collection<ListingItem>> {
@@ -44,6 +43,12 @@ export class ListingItemRepository {
      */
     public async findAllByHash(hash: string, withRelated: boolean = true): Promise<Bookshelf.Collection<ListingItem>> {
         return this.ListingItemModel.fetchAllByHash(hash, withRelated);
+    }
+
+    public async findAllByHashAndMarketReceiveAddress(
+        hash: string, marketReceiveAddress: string, withRelated: boolean = true
+    ): Promise<Bookshelf.Collection<ListingItem>> {
+        return this.ListingItemModel.fetchAllByHashAndMarketReceiveAddress(hash, marketReceiveAddress, withRelated);
     }
 
     public async findOne(id: number, withRelated: boolean = true): Promise<ListingItem> {

--- a/src/api/services/action/ListingItemAddActionService.ts
+++ b/src/api/services/action/ListingItemAddActionService.ts
@@ -157,6 +157,16 @@ export class ListingItemAddActionService extends BaseActionService {
                     // if there's a Proposal to remove the ListingItem, create a FlaggedItem related to the ListingItem
                     await this.createFlaggedItemIfNeeded(listingItem);
 
+                    // if this is a duplicated listingitem and the user has previously flagged the listing item, ensure that this item receives the same vote.
+                    await this.listingItemService.findAllByHashAndMarketReceiveAddress(listingItem.hash, listingItem.market).then(value => {
+                        const sameListings: resources.ListingItem[] = value.toJSON();
+                        const isRemovedByUser = sameListings.find(listing => !!listing.removed);
+
+                        if (isRemovedByUser) {
+                            this.listingItemService.setRemovedFlag(listingItem.id, true);
+                        }
+                    });
+
                     // if there's a matching ListingItemTemplate, create a relation
                     await this.updateListingItemAndTemplateRelationIfNeeded(listingItem);
 

--- a/src/api/services/model/FlaggedItemService.ts
+++ b/src/api/services/model/FlaggedItemService.ts
@@ -92,21 +92,24 @@ export class FlaggedItemService {
 
         switch (proposal.category) {
             case ProposalCategory.ITEM_VOTE:
-                const listingItem: resources.ListingItem = await this.listingItemService.findOneByHashAndMarketReceiveAddress(proposal.target, proposal.market)
-                    .then(value => value.toJSON());
+                const listingItems: resources.ListingItem[] = await this.listingItemService.findAllByHashAndMarketReceiveAddress(
+                    proposal.target,
+                    proposal.market
+                ).then(value => value.toJSON());
 
-                let flaggedItem: resources.FlaggedItem;
-
-                if (_.isEmpty(listingItem.FlaggedItem)) {
-                    flaggedItem = await this.create({
-                        proposal_id: proposal.id,
-                        listing_item_id: listingItem.id,
-                        reason: proposal.description
-                    } as FlaggedItemCreateRequest).then(value => value.toJSON());
-                } else {
-                    flaggedItem = await this.findOne(listingItem.FlaggedItem.id).then(value => value.toJSON());
+                for (const listingItem of listingItems) {
+                    let flaggedItem: resources.FlaggedItem;
+                    if (_.isEmpty(listingItem.FlaggedItem)) {
+                        flaggedItem = await this.create({
+                            proposal_id: proposal.id,
+                            listing_item_id: listingItem.id,
+                            reason: proposal.description
+                        } as FlaggedItemCreateRequest).then(value => value.toJSON());
+                    } else {
+                        flaggedItem = await this.findOne(listingItem.FlaggedItem.id).then(value => value.toJSON());
+                    }
+                    flaggedItems.push(flaggedItem);
                 }
-                flaggedItems.push(flaggedItem);
                 break;
 
             case ProposalCategory.MARKET_VOTE:

--- a/src/api/services/model/ListingItemService.ts
+++ b/src/api/services/model/ListingItemService.ts
@@ -67,6 +67,19 @@ export class ListingItemService {
         return await this.listingItemRepo.findAllByHash(hash, withRelated);
     }
 
+    /**
+     *
+     * @param {string} hash
+     * @param marketReceiveAddress
+     * @param {boolean} withRelated
+     * @returns {Promise<Bookshelf.Collection<ListingItem>>}
+     */
+     public async findAllByHashAndMarketReceiveAddress(
+        hash: string, marketReceiveAddress: string, withRelated: boolean = true
+    ): Promise<Bookshelf.Collection<ListingItem>> {
+        return await this.listingItemRepo.findAllByHashAndMarketReceiveAddress(hash, marketReceiveAddress, withRelated);
+    }
+
     public async findOne(id: number, withRelated: boolean = true): Promise<ListingItem> {
         const listingItem = await this.listingItemRepo.findOne(id, withRelated);
         if (listingItem === null) {


### PR DESCRIPTION
A "duplicated listing item" in this case is a listing item in the same market as another with the same listing hash.

This change fixes 2 particular issues:
1. When a listing item is flagged, all of the duplicates are now flagged as well;
2. When a duplicate listing item is created (either the listing item is created by the seller or a duplicated listing item is received via smsg service), then if one of the copies has been voted on to be removed then the newly created copy shares that same vote.