### PR TITLE
Fixes incorrect favorite item being removed

### DIFF
--- a/src/api/commands/favorite/FavoriteRemoveCommand.ts
+++ b/src/api/commands/favorite/FavoriteRemoveCommand.ts
@@ -39,7 +39,8 @@ export class FavoriteRemoveCommand extends BaseCommand implements RpcCommandInte
 
     @validate()
     public async execute( @request(RpcRequest) data: RpcRequest): Promise<void> {
-        return this.favoriteItemService.destroy(data.params[0]);
+        const favItem: resources.FavoriteItem = data.params[0];
+        return this.favoriteItemService.destroy(favItem.id);
     }
 
     public async validate(data: RpcRequest): Promise<RpcRequest> {


### PR DESCRIPTION
While a numeric id is passed in to the FavoriteRemoveCommand, validation routines actually fetch the JSON representation of the FavoriteItem to be removed, and it is this JSON representation that is passed as the first param to the `execute()` function. Passing the whole object to the destroy call results in an incorrect match being found (typically the first FavoriteItem, or in other words, the FavoriteItem with the smallest id value), and thus the incorrect FavoriteItem is removed.

This change is to simply pass the found FavoriteItem's id, rather than the entire JSON object representation of the FavoriteItem, as an arg to the destroy function call, such that the correct FavoriteItem can be found and removed.