### PR TITLE
Fixes an error that prevents a bid from being placed.

### DIFF
--- a/src/api/factories/message/ListingItemImageAddMessageFactory.ts
+++ b/src/api/factories/message/ListingItemImageAddMessageFactory.ts
@@ -100,7 +100,10 @@ export class ListingItemImageAddMessageFactory extends BaseMessageFactory {
         if (withData) {
             // load the actual image data
             // we're not sending the image data anymore when posting the ListingItem
-            data = await this.imageDataService.loadImageFile(imageData.imageHash, imageData.imageVersion);
+            data = await this.imageDataService.loadImageFile(imageData.imageHash, imageData.imageVersion).catch(err => {
+                this.log.error(err);
+                return undefined;
+            });
         }
 
         dsns.push({


### PR DESCRIPTION
When a bid is being placed on a listing that contains one or more images that may not exist correctly on disk (the image has not been received, for example), then the bid on the listing item fails with an exception being thrown for `Image load failed`.

This change simply catches the error being raised and handles it by setting the expected data base64 image string to be undefined.
There doesn't seem to be a point to requesting the image datas specifically during the bid process, but thats beside the point anyway. The bid process does not appear to use the actual images to sign the bid requests, so returning an undefined value appears to resolve the issue.
