### PR TITLE
Fixes buyflow message validation: cancellation vs escrow complete

### DIFF
--- a/src/api/services/action/BidActionService.ts
+++ b/src/api/services/action/BidActionService.ts
@@ -141,7 +141,9 @@ export class BidActionService extends BaseActionService {
         const marketReceiveAddressKVS: KVS | undefined = _.find(bidMessage.objects || [], (kvs: KVS) => {
             return kvs.key === ActionMessageObjects.BID_ON_MARKET;
         });
+        // tslint:disable:no-useless-cast
         const marketReceiveAddress = marketReceiveAddressKVS!.value as string;
+        // tslint:enable:no-useless-cast
         // smsgMessage.to should be the same?
 
         // find the ListingItem the Bid is for
@@ -198,17 +200,19 @@ export class BidActionService extends BaseActionService {
 
         // if we're the buyer, Order hash was generated before posting the BidMessage to the seller
         // if we're the seller, we should have received the Order hash from the buyer in the message
-        const orderHash = _.find(bidMessage.objects || [], (kvs: KVS) => {
+        const orderHash: any | undefined = _.find(bidMessage.objects || [], (kvs: KVS) => {
             return kvs.key === ActionMessageObjects.ORDER_HASH;
         });
         this.log.debug('createBid(), orderHash: ', orderHash);
 
+        // tslint:disable:no-useless-cast
         const orderCreateRequest: OrderCreateRequest = await this.orderFactory.get({
                 actionMessage: marketplaceMessage.action as BidMessage,
                 smsgMessage,
                 bids: [bid],
                 hash: orderHash!.value
             } as OrderCreateParams);
+        // tslint:enable:no-useless-cast
 
         await this.orderService.create(orderCreateRequest).then(value => value.toJSON());
 

--- a/src/api/services/model/OrderItemService.ts
+++ b/src/api/services/model/OrderItemService.ts
@@ -44,6 +44,9 @@ export class OrderItemService {
         this.madctBuyFlowSequence[OrderItemStatus.SHIPPING] = {
             nextStates: [OrderItemStatus.COMPLETE]
         };
+        this.madctBuyFlowSequence[OrderItemStatus.BID_CANCELLED] = {
+            nextStates: [OrderItemStatus.ESCROW_COMPLETED]
+        };
     }
 
     public async findAll(): Promise<Bookshelf.Collection<OrderItem>> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6894,9 +6894,9 @@ particl-bitcore-lib@^0.16.0:
     inherits "=2.0.1"
     lodash "=4.17.11"
 
-"particl-bitcore-lib@git+https://github.com/kewde/particl-bitcore-lib.git":
+"particl-bitcore-lib@https://github.com/kewde/particl-bitcore-lib.git":
   version "0.14.1"
-  resolved "git+https://github.com/kewde/particl-bitcore-lib.git#612c7b7b77385051168ef3831c4c2451eb807ffd"
+  resolved "https://github.com/kewde/particl-bitcore-lib.git#612c7b7b77385051168ef3831c4c2451eb807ffd"
   dependencies:
     bn.js "=2.0.4"
     bs58 "=2.0.0"


### PR DESCRIPTION
Allows for the buyflow state to progress from being cancelled to escrow complete.

This ensures that in a scenario in which the buyer and seller concurrently cancel and complete the escrow step, that the buyer node correctly updates to reflect that the escrow was in fact, completed. Without this, the buyer node remains in a "cancelled" state, and is unable to thus progress the buyflow.

This does not affect the case where the buyer cancels and the seller attempts to complete the escrow and the associated buyer-locked funds have been spent. In such a case, an error is still generated and correctly prevents the seller from completing the escrow.