### PR TITLE
Allow for graceful shutdown of the service

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,7 +137,7 @@
     "fsevents": "^2.1.3"
   },
   "engines": {
-    "node": ">=12.*.*"
+    "node": ">=14.*.*"
   },
   "jest": {
     "verbose": true,
@@ -223,11 +223,11 @@
     "sonarqube-scanner": "^2.1.2",
     "trash-cli": "^1.4.0",
     "ts-jest": "<23.10.0",
-    "ts-node": "^3.2.0",
+    "ts-node": "^3.3.0",
     "tslint": "5.11.0",
     "tslint-clean-code": "^0.2.7",
     "tslint-sonarts": "^1.8.0",
-    "zombie": "^6.1.2",
-    "zeromq": "^5.2.8"
+    "zeromq": "^5.2.8",
+    "zombie": "^6.1.2"
   }
 }

--- a/src/core/App.ts
+++ b/src/core/App.ts
@@ -72,6 +72,10 @@ export class App {
         return this.socketIoServer;
     }
 
+    get ZmqWorker(): ZmqWorker {
+        return this.zmqWorker;
+    }
+
     public Logger(scope: string): Logger {
         return new Logger(scope || __filename);
     }

--- a/src/core/ZmqWorker.ts
+++ b/src/core/ZmqWorker.ts
@@ -73,21 +73,21 @@ export class ZmqWorker {
             );
         });
 
-        particld.on('hashblock', (hash) => {
-            this.log.debug('ZMQ: receive(hashblock): ', hash.toString('hex'));
-        });
+        // particld.on('hashblock', (hash) => {
+        //     this.log.debug('ZMQ: receive(hashblock): ', hash.toString('hex'));
+        // });
 
-        particld.on('hashtx', (hash) => {
-            this.log.debug('ZMQ: receive(hashtx): ', hash.toString('hex'));
-        });
+        // particld.on('hashtx', (hash) => {
+        //     this.log.debug('ZMQ: receive(hashtx): ', hash.toString('hex'));
+        // });
 
-        particld.on('rawblock', (block) => {
-            this.log.debug('ZMQ: receive(rawblock): ', block.toString('hex'));
-        });
+        // particld.on('rawblock', (block) => {
+        //     this.log.debug('ZMQ: receive(rawblock): ', block.toString('hex'));
+        // });
 
-        particld.on('rawtx', (tx) => {
-            this.log.debug('ZMQ: receive(rawtx): ', tx.toString('hex'));
-        });
+        // particld.on('rawtx', (tx) => {
+        //     this.log.debug('ZMQ: receive(rawtx): ', tx.toString('hex'));
+        // });
 
         particld.on('connect:*', (uri, type) => {
             this.isConnected = true;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4221,6 +4221,13 @@ homedir-polyfill@^1.0.0:
   dependencies:
     parse-passwd "^1.0.0"
 
+homedir-polyfill@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz#743298cef4e5af3e194161fbadcc2151d3a058e8"
+  integrity sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==
+  dependencies:
+    parse-passwd "^1.0.0"
+
 hosted-git-info@^2.1.4:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.4.2.tgz#0076b9f46a270506ddbaaea56496897460612a67"
@@ -6894,9 +6901,9 @@ particl-bitcore-lib@^0.16.0:
     inherits "=2.0.1"
     lodash "=4.17.11"
 
-"particl-bitcore-lib@git+https://github.com/kewde/particl-bitcore-lib.git":
+"particl-bitcore-lib@https://github.com/kewde/particl-bitcore-lib.git":
   version "0.14.1"
-  resolved "git+https://github.com/kewde/particl-bitcore-lib.git#612c7b7b77385051168ef3831c4c2451eb807ffd"
+  resolved "https://github.com/kewde/particl-bitcore-lib.git#612c7b7b77385051168ef3831c4c2451eb807ffd"
   dependencies:
     bn.js "=2.0.4"
     bs58 "=2.0.0"
@@ -8831,10 +8838,10 @@ ts-jest@<23.10.0:
     json5 "^0.5.0"
     lodash "^4.17.10"
 
-ts-node@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-3.2.0.tgz#9814f0c0141784900cf12fef1197ad4b7f4d23d1"
-  integrity sha1-mBTwwBQXhJAM8S/vEZetS39NI9E=
+ts-node@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-3.3.0.tgz#c13c6a3024e30be1180dd53038fc209289d4bf69"
+  integrity sha1-wTxqMCTjC+EYDdUwOPwgkonUv2k=
   dependencies:
     arrify "^1.0.0"
     chalk "^2.0.0"
@@ -8844,7 +8851,7 @@ ts-node@^3.2.0:
     mkdirp "^0.5.1"
     source-map-support "^0.4.0"
     tsconfig "^6.0.0"
-    v8flags "^2.0.11"
+    v8flags "^3.0.0"
     yn "^2.0.0"
 
 tsconfig@^6.0.0:
@@ -9191,12 +9198,19 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.3.2.tgz#1b4af4955eb3077c501c23872fc6513811587131"
   integrity sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==
 
-v8flags@^2.0.11, v8flags@^2.0.2:
+v8flags@^2.0.2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-2.1.1.tgz#aab1a1fa30d45f88dd321148875ac02c0b55e5b4"
   integrity sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=
   dependencies:
     user-home "^1.1.1"
+
+v8flags@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.2.0.tgz#b243e3b4dfd731fa774e7492128109a0fe66d656"
+  integrity sha512-mH8etigqMfiGWdeXpaaqGfs6BndypxusHHcv2qSHyZkGEznCd/qAXCWWRzeowtL54147cktFOC4P5y+kl8d8Jg==
+  dependencies:
+    homedir-polyfill "^1.0.1"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
By terminating with SIGINT, the application/service is immediately typically terminated. This can lead to a case in which the processing of message received is only partially completed.

This change attempts to change this behaviour, and allow for a more graceful shutdown in which some additional time is available for any processing of a message to be completed. By trapping the sigint (and other termination events), certain services (eg: the zmq channels, and message queues) are paused or stopped. Then, whichever occurs soonest between the nodejs event queue becoming empty (nothing more to process) or a 2 second window elapsing (default option, can be adjusted), the process is finally terminated. This should hopefully allow any message in the processing stage some time to finish, without any new messages entering the processing state.

This is not the ideal way to achieve this, particularly since the flushing of certain message writes to disk (via the DB) may not be completed in the window. But it provides an attempt at graceful shutdown without significant code change at the current time (ie: its a stopgap for now), and the process can always be adjusted/updated later as part of a bigger change.

Also, the change to using fork instead of spawn for the child process, and the associated ipc message passing between the parent and child process, was necessary due to Windows behaviour around handling signint.